### PR TITLE
improve readability run_cmd() error message

### DIFF
--- a/repowatch/repowatch.py
+++ b/repowatch/repowatch.py
@@ -320,17 +320,17 @@ class RepoWatch:
 
         p = subprocess.Popen(cmd.split(),
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
                              env=env_dict,
                              **kwargs)
         out, err = p.communicate()
+        out = out.strip()
         if p.returncode != 0:
-            self.logger.error("Nonzero return code\n" \
-                              "Code: {0} Exec: {1}\n" \
-                              "Output: {2} Error: {3}".format(p.returncode,
-                                                               cmd,
-                                                               repr(out),
-                                                               repr(err)))
+            self.logger.error("Nonzero return code. "\
+                              "Code {0}, Exec: {1}, "\
+                              "Output: {2}".format(p.returncode,
+                                                    repr(cmd), 
+                                                    repr(out)))
         else:
             return out
 


### PR DESCRIPTION
omits new line characters as rsyslog replaces control characters during
reception of the message [1].  This causes the '\n' character to get
replaced with '#012'.

redirects stderr to stdout

New Error:

RepoWatch: Nonzero return code. Code 128, Exec: 'git checkout -f
FETCH_HEAD ', Output: 'fatal: Not a git repository (or any of the parent
directories): .git'

Old Error:

RepoWatch: Nonzero return code#012Code: 128 Exec: git checkout -f
FETCH_HEAD #012Output: '' Error: 'fatal: Not a git repository (or any of
the parent directories): .git\n'

[1] http://www.rsyslog.com/doc/rsconf1_escapecontrolcharactersonreceive.html
