### PR TITLE
only fix permissions for the branch that was updated

### DIFF
--- a/repowatch/repowatch.py
+++ b/repowatch/repowatch.py
@@ -390,12 +390,12 @@ class RepoWatch:
         self.run_cmd('find {0} ' \
                      '-type f ' \
                      '-not -path *.git* ' \
-                     '-exec chmod 644 {{}} ;'.format(dirname(fullpath)))
+                     '-exec chmod 644 {{}} ;'.format(fullpath))
 
         self.run_cmd('find {0} ' \
                      '-type d ' \
                      '-not -path *.git* ' \
-                     '-exec chmod 755 {{}} ;'.format(dirname(fullpath)))
+                     '-exec chmod 755 {{}} ;'.format(fullpath))
 
 
     def delete_branch(self, project_name, branch_name):


### PR DESCRIPTION
If I have the following directories
/data/code/myrepo/branch1
/data/code/myrepo/branch2
/data/code/myrepo/branch3

the code currently runs
`git checkout branch1
find /data/code/myrepo`

The patch results in
`git checkout branch1
find /data/code/myrepo/branch1`

Running find on all branches after a branch update becomes costly when there are many files in the repo and many branches.
