### PR TITLE
log error when lock file acquisition fails

### DIFF
--- a/repowatch/repowatch.py
+++ b/repowatch/repowatch.py
@@ -503,9 +503,9 @@ class RepoWatch:
                 for name, thread in self.threads.items():
                     thread.start()
                 self.main_loop()
-        except pidlockfile.LockTimeout:
-            logging.exception('Lockfile timeout while attempting to acquire lock, '
-                              'are we already running?')
+        except lockfile.LockTimeout:
+            logging.error('Lockfile timeout while attempting to acquire lock, '
+                          'are we already running?')
         finally:
             self.logger.info('Shutting down')
             try:
@@ -513,7 +513,8 @@ class RepoWatch:
             except:
                 self.logger.info('No SSH wrapper to clean?')
             for name, thread in self.threads.items():
-                thread.join(2)
+                if thread.is_alive():
+                    thread.join(2)
             sys.exit(0)
 
 def main():


### PR DESCRIPTION
without patch

```
INFO:RepoWatch:Reading config
INFO:RepoWatch:Finished config
ERROR:root:Lockfile timeout while attempting to acquire lock, are we already running?
Traceback (most recent call last):
  File "repowatch.py", line 487, in run
    pidfile.acquire(timeout=2)
  File "/usr/lib/python2.7/site-packages/lockfile/pidlockfile.py", line 85, in acquire
    raise LockTimeout
LockTimeout
INFO:RepoWatch:Shutting down
Traceback (most recent call last):
  File "repowatch.py", line 527, in <module>
    main()
  File "repowatch.py", line 524, in main
    watcher.run()
  File "repowatch.py", line 509, in run
    thread.join(2)
  File "/usr/lib64/python2.7/threading.py", line 939, in join
    raise RuntimeError("cannot join thread before it is started")
RuntimeError: cannot join thread before it is started
```

With Patch

```
INFO:RepoWatch:Reading config
INFO:RepoWatch:Finished config
ERROR:root:Lockfile timeout while attempting to acquire lock, are we already running?
INFO:RepoWatch:Shutting down
```
