### PR TITLE
run `git init` if .git does not exist

### DIFF
--- a/repowatch/repowatch.py
+++ b/repowatch/repowatch.py
@@ -369,7 +369,10 @@ class RepoWatch:
 
         self.logger.info('Update repo branch: {0}:{1} in {2}'.format(project_name, branch_name, fullpath))
 
-        if not os.path.isdir(fullpath):
+        if os.path.isdir(fullpath):
+            if not os.path.isdir(os.path.join(fullpath, '.git')):
+                self.run_cmd('git init', cwd=fullpath)
+        else:
             # create branch dir
             os.makedirs(fullpath)
             self.run_cmd('git init', cwd=fullpath)


### PR DESCRIPTION
When bootstrapping a puppet server, I copy a few branches over manually, using git-archive. As a result, git commands fails because the directory does not have a `.git` directory.

This patch will create an `.git` directory if one does not exist.

I realize this is probably an edge case, an alternative approach would be to print an error if `.git` does not exist and skip the branch update.
