### PR TITLE
pass current environmental variables to subprocess

### DIFF
--- a/repowatch/repowatch.py
+++ b/repowatch/repowatch.py
@@ -317,7 +317,9 @@ class RepoWatch:
         # Ensure the GIT_SSH wrapper is present
         if not os.path.isfile(self.wrapper):
             self.create_ssh_wrapper()
-        env_dict = dict(GIT_SSH=self.wrapper)
+
+        env_dict = os.environ.copy()
+        env_dict['GIT_SSH'] = self.wrapper
         if ssh_key:
             env_dict['PKEY'] = ssh_key
 


### PR DESCRIPTION
Basically external scripts that call commands without using the absolute path, fail. I have a script that calls puppet, however puppet fails because the executable `hostname` can't be found.

Strictly speaking, we only need to export PATH to solve my particular issue. However I think inheriting current environmental variables provides greater flexibility.
