### PR TITLE
disable stirct host key checking

### DIFF
--- a/repowatch/repowatch.py
+++ b/repowatch/repowatch.py
@@ -42,9 +42,9 @@ GIT_SSH_WRAPPER = '''#!/bin/sh
 
 if [ -z "$PKEY" ]; then
     # if PKEY is not specified, run ssh using default keyfile
-    ssh "$@"
+    ssh -oStrictHostKeyChecking=no "$@"
 else
-    ssh -i "$PKEY" "$@"
+    ssh -oStrictHostKeyChecking=no -i "$PKEY" "$@"
 fi
 '''
 


### PR DESCRIPTION
git will fail due to host key verification until until the user accepts
the remote ssh key. This change will always accept the remote key.
