### PR TITLE
add /etc/ssh/ssh_known_hosts2 to list of files to check for hostkey

### DIFF
--- a/repowatch/__init__.py
+++ b/repowatch/__init__.py
@@ -174,7 +174,8 @@ class RepoWatch(object):
 
             known_host_files = [
                 os.path.join(os.path.expanduser('~'), '.ssh/known_hosts'),
-                '/etc/ssh/ssh_known_hosts']
+                '/etc/ssh/ssh_known_hosts',
+                '/etc/ssh/ssh_known_hosts2']
 
             for known_host_file in known_host_files:
                 known = run_cmd('ssh-keygen -F {0} -f {1}'.format(hostname, known_host_file),


### PR DESCRIPTION
Add support for hostkeys that exist in '/etc/ssh/ssh_known_hosts2' file. From what I can tell, the value of these checks is error-ing out a earlier/little cleaner. Given that, an alternative could be to remove this check all together, and find a way to handle ssh errors in a similar manor. 
 